### PR TITLE
Update Build Configuration in tsup.config.ts ISSUE 6

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -2,28 +2,28 @@ import { defineConfig } from 'tsup';
 
 export default defineConfig([
     {
-      entry: ['src/main.ts'],
-      format: ['cjs'],
-      dts: { entry: 'src/types.ts' },  // Generates a types file
-      minify: false,
-      sourcemap: false,
-      outDir: 'dist',
-      outExtension: () => ({ js: '.runtime.js' }), // CommonJS runtime file
+        entry: ['src/main.ts'],
+        format: ['cjs'],
+        dts: { entry: 'src/types.ts' },  // Generates a types file
+        minify: false,                   // Ensure this is false for non-minified output
+        sourcemap: false,
+        outDir: 'build',                 // Change output directory to build
+        outExtension: () => ({ js: '.runtime.js' }), // CommonJS runtime file
     },
     {
-      entry: ['src/main.ts'],
-      format: ['esm'],
-      minify: true,
-      sourcemap: false,
-      outDir: 'dist',
-      outExtension: () => ({ js: '.min.js' }), // ESM minified file
+        entry: ['src/main.ts'],
+        format: ['esm'],
+        minify: true,                    // Keep minification for ESM
+        sourcemap: false,
+        outDir: 'build',                 // Change output directory to build
+        outExtension: () => ({ js: '.min.js' }), // ESM minified file
     },
     {
-      entry: ['src/main.ts'],
-      format: ['cjs'],
-      minify: true,
-      sourcemap: false,
-      outDir: 'dist',
-      outExtension: () => ({ js: '.js' }), // Unminified hmpl.js
+        entry: ['src/main.ts'],
+        format: ['cjs'],
+        minify: false,                   // Ensure this is false for non-minified output
+        sourcemap: false,
+        outDir: 'build',                 // Change output directory to build
+        outExtension: () => ({ js: '.js' }), // Unminified hmpl.js
     }
-  ]);
+]);


### PR DESCRIPTION
This pull request addresses the following updates to the tsup.config.ts file:
## Output Directory Change:
The output directory for all build files has been changed from dist to build. This adjustment helps in organizing build artifacts better and avoids potential conflicts with existing files in the dist folder.
## Minification Adjustments:
The CommonJS configuration now ensures that main.js is generated without minification, providing a more readable version of the code.

The ESM configuration retains minification for production use, generating a minified output file named .min.js.
These changes enhance the clarity and usability of the build process, making it easier for developers to work with the output files.

Additionally, this update is related to Issue #6, which highlighted the need for clearer build outputs and non-minified files for development purposes.

Please review these changes and let me know if there are any questions or further modifications needed. Feel free to adjust any part of this message as necessary!