### PR TITLE
updated old twitter logo in the footer

### DIFF
--- a/www/blog/_config.yml
+++ b/www/blog/_config.yml
@@ -11,5 +11,5 @@ plugins:
 minima:
   social_links:
     - { platform: github, user_url: "https://github.com/hmpl-language/hmpl" }
-    - { platform: twitter, user_url: "https://x.com/hmpljs" }
+    - { platform: x, user_url: "https://x.com/hmpljs" }
     - { platform: rss, user_url: "/feed.xml" }

--- a/www/blog/_includes/social-item.html
+++ b/www/blog/_includes/social-item.html
@@ -1,7 +1,11 @@
 <li>{% assign entry = include.item %}
-  <a {% unless entry.platform == 'rss' %}rel="me" {% endunless %}href="{{ entry.user_url }}" target="_blank" title="{{ entry.title | default: entry.platform }}">
+  <a {% unless entry.platform=='rss' %}rel="me" {% endunless %}href="{{ entry.user_url }}" target="_blank" title="{{ entry.title | default: entry.platform }}">
     <svg class="svg-icon grey">
+      {% if entry.platform == 'x' %}
+      <path d="M12.6.75h2.454l-5.36 6.142L16 15.25h-4.937l-3.867-5.07-4.425 5.07H.316l5.733-6.57L0 .75h5.063l3.495 4.633L12.601.75Zm-.86 13.028h1.36L4.323 2.145H2.865z"></path>
+      {% else %}
       <use xlink:href="{{ '/assets/minima-social-icons.svg#' | append: entry.platform | relative_url }}"></use>
+      {% endif %}
     </svg>
   </a>
 </li>


### PR DESCRIPTION
**Description:**

The Minima theme doesn't currently support the X (formerly Twitter) logo, and the related issue [#777](https://github.com/jekyll/minima/issues/777) is still open. To resolve this, I added an `if` condition in `social-item.html` to check for the `x` platform. If it's X, the custom SVG logo is rendered; otherwise, the standard `<use>` tag is used for other platforms.

**Changes Made:**
1. Conditional rendering for X logo.
2. Fallback to the existing behavior for other platforms.

This fixes the issue of displaying the X logo in the theme. [Image Preview](https://ibb.co/CpdszCR)

**Related Issue:**  
- #10