### PR TITLE
feat: Add copy-to-clipboard functionality for code blocks (#40)

### DIFF
--- a/www/blog/_layouts/base.html
+++ b/www/blog/_layouts/base.html
@@ -1,21 +1,55 @@
 <!DOCTYPE html>
-<html lang="{{ page.lang | default: site.lang | default: "en" }}">
+<html lang="{{ page.lang | default: site.lang | default: " en" }}">
 
-  {%- include head.html -%}
-  <link rel="stylesheet" href="/css/style.css" />
-  <body>
+{%- include head.html -%}
+<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.11/clipboard.min.js"></script>
+<link rel="stylesheet" href="/css/style.css" />
 
-    {%- include header.html -%}
+<body>
 
-    <main class="page-content" aria-label="Content">
-      <div class="wrapper">
-        {% include breadcrumbs.html %}
-        {{ content }}
-      </div>
-    </main>
+  {%- include header.html -%}
 
-    {%- include footer.html -%}
+  <main class="page-content" aria-label="Content">
+    <div class="wrapper">
+      {% include breadcrumbs.html %}
+      {{ content }}
+    </div>
+  </main>
 
-  </body>
+  {%- include footer.html -%}
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      const codeBlocks = document.querySelectorAll('pre code');
+
+      codeBlocks.forEach((codeBlock) => {
+        const container = codeBlock.parentNode;
+
+        const button = document.createElement('button');
+        button.classList.add('copy-btn');
+
+        // const lang = container.closest('[class^="language-"]').classList[0].split('-')[1];
+        // button.textContent = lang;
+
+        container.style.position = 'relative';
+        container.appendChild(button);
+
+        new ClipboardJS(button, {
+          target: function () {
+            return codeBlock;
+          }
+        });
+
+        button.addEventListener('click', function () {
+          button.classList.add('copied');
+          setTimeout(() => {
+            button.classList.remove('copied')
+          }, 1500);
+          window.getSelection().removeAllRanges();
+        });
+      });
+    });
+  </script>
+
+</body>
 
 </html>

--- a/www/blog/css/style.css
+++ b/www/blog/css/style.css
@@ -20,7 +20,7 @@
   margin-bottom: 0;
 }
 
-.social-media-list li + li {
+.social-media-list li+li {
   padding-top: 0;
 }
 
@@ -36,4 +36,49 @@
 
 #breadcrumbs {
   margin-bottom: 1.5rem;
+}
+
+.copy-btn {
+  --copy-icon: url('data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 512 512%22 xml:space=%22preserve%22%3E%3Cpath fill=%22gray%22 d=%22M179.2 51.2H128c-42.4 0-76.8 34.4-76.8 76.8v307.2c0 42.4 34.4 76.8 76.8 76.8h256c42.4 0 76.8-34.4 76.8-76.8V128c0-42.4-34.4-76.8-76.8-76.8h-51.2c-14.1 0-25.6 11.5-25.6 25.6s11.5 25.6 25.6 25.6H384c14.1 0 25.6 11.5 25.6 25.6v307.2c0 14.1-11.5 25.6-25.6 25.6H128c-14.1 0-25.6-11.5-25.6-25.6V128c0-14.1 11.5-25.6 25.6-25.6h51.2c14.1 0 25.6-11.5 25.6-25.6s-11.5-25.6-25.6-25.6%22/%3E%3Cpath fill=%22gray%22 d=%22M230.4 25.6v25.6h51.2c14.1 0 25.6 11.5 25.6 25.6s-11.5 25.6-25.6 25.6h-51.2c-14.1 0-25.6-11.5-25.6-25.6s11.5-25.6 25.6-25.6zV0c-42.4 0-76.8 34.4-76.8 76.8s34.4 76.8 76.8 76.8h51.2c42.4 0 76.8-34.4 76.8-76.8S324 0 281.6 0h-51.2z%22/%3E%3C/svg%3E');
+  --copied-icon: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" xml:space="preserve"%3E%3Cpath fill="gray" d="M179.2 51.2H128c-42.4 0-76.8 34.4-76.8 76.8v307.2c0 42.4 34.4 76.8 76.8 76.8h256c42.4 0 76.8-34.4 76.8-76.8V128c0-42.4-34.4-76.8-76.8-76.8h-51.2c-14.1 0-25.6 11.5-25.6 25.6s11.5 25.6 25.6 25.6H384c14.1 0 25.6 11.5 25.6 25.6v307.2c0 14.1-11.5 25.6-25.6 25.6H128c-14.1 0-25.6-11.5-25.6-25.6V128c0-14.1 11.5-25.6 25.6-25.6h51.2c14.1 0 25.6-11.5 25.6-25.6s-11.5-25.6-25.6-25.6"%3E%3C/path%3E%3Cpath fill="gray" d="M230.4 25.6v25.6h51.2c14.1 0 25.6 11.5 25.6 25.6s-11.5 25.6-25.6 25.6h-51.2c-14.1 0-25.6-11.5-25.6-25.6s11.5-25.6 25.6-25.6zV0c-42.4 0-76.8 34.4-76.8 76.8s34.4 76.8 76.8 76.8h51.2c42.4 0 76.8-34.4 76.8-76.8S324 0 281.6 0h-51.2zm-69.3 299.7 51.2 51.2c4.8 4.8 11.4 7.5 18.1 7.5s13.3-2.7 18.1-7.5l102.4-102.4c10-10 10-26.2 0-36.2s-26.2-10-36.2 0l-84.3 84.3-33.1-33.1c-10-10-26.2-10-36.2 0s-10 26.2 0 36.2"%3E%3C/path%3E%3C/svg%3E');
+
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  padding: 5px;
+
+  height: 30px;
+  width: 30px;
+  background-image: var(--copy-icon);
+  background-size: 60%;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-color: #0000;
+  color: #383A42;
+  border: none;
+  cursor: pointer;
+  border-radius: 5px;
+  opacity: 0;
+  transition: opacity 0.3s;
+}
+
+.copy-btn:hover {
+  background-color: #cce6f9;
+}
+
+.copy-btn.copied {
+  opacity: 1;
+  background-image: var(--copied-icon);
+}
+
+pre {
+  position: relative;
+  padding: 10px;
+  background-color: #f5f5f5;
+  border-radius: 5px;
+  overflow-x: auto;
+}
+
+pre:hover .copy-btn {
+  opacity: 1;
 }


### PR DESCRIPTION
- Added a "Copy" button to all code blocks on the blog site.
- Clicking the button copies the respective code block content to the clipboard.

Closes #40. Let me know if there are any design or functionality adjustments you'd like!