### PR TITLE
fix #116:The layout of the star component is twitching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hmpl-js",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hmpl-js",
-      "version": "3.0.2",
+      "version": "3.0.3",
       "license": "MIT",
       "dependencies": {
         "dompurify": "^3.2.4",

--- a/www/app/docs/.vuepress/styles/palette.scss
+++ b/www/app/docs/.vuepress/styles/palette.scss
@@ -85,15 +85,16 @@ a::before {
 .star {
   width: 20px;
   height: 20px;
+  
 }
 
 .github-stars {
   display: flex;
-  justify-content: center;
+  justify-content:center;
   align-items: center;
   height: 32px;
   padding: 6px 2px;
-  gap: 4px;
+  gap: 8px;
   margin: 0 10px 0 4px !important;
 
   @media (max-width: 768px) {
@@ -105,11 +106,12 @@ a::before {
   color: #3c3c43c7;
   font-size: 18px;
   display: flex;
-  min-width: 30px;
+  min-width:40px;
   align-items: center;
   justify-content: start;
   padding-top: 1px;
   height: 100%;
+
 }
 
 .github-stars:hover {


### PR DESCRIPTION
**what does this PR do**
- this pr fixes the twitching of three dot when we do reloads by just increasing width of the stars and no. of stars and increasing the div gaps.

fixes #116 

**Changes Made:**
- Increased the width of the star container to fix twitching.

**find issue**
There is a small bug where the star rating number is not displaying correctly — instead of the number of stars, only three dots (...) appear. I’m not sure why this happens yet, but it started after increasing the width. This will need further investigation.