### PR TITLE
Fix layout shift between Loading... and ✦✦✦ (star) on main page (#116)

### DIFF
--- a/www/app/example.hmpl
+++ b/www/app/example.hmpl
@@ -1,50 +1,63 @@
 <div>
-    {{#request
-        src="/api/test"
-        method="get"
-        after="click:.target"
-        repeat=true
-        interval=1000
-        indicators=[
-            {
-                trigger: "pending"
-                content: "&lt;p&gt;Loading...&lt;/p&gt;"
-            },
-            {
-                trigger: "rejected"
-                content: "&lt;p&gt;Error&lt;/p&gt;&lt;button&gt;reload&lt;/button&gt;"
-            }
-        ]
-        autoBody={
-            formData: true
-        }
-        memo=true
-        initId="id1"
-        allowedContentTypes=["text/html"]
-        disallowedTags=["script" "style" "iframe"]
-        sanitize=false
-    }}{{/request}}
-    {{r src="/api/test2"}}{{/r}}
-    {{#request
-      src="/api/register"
-      after="submit:#form"
-      repeat=false
-      indicators=[
-        {
-          trigger: "pending",
-          content: "<p>Loading...</p>"
-        }
-      ]
-    }}
-    {{/request}}
+  {{#request
+    src="/api/test"
+    method="get"
+    after="click:.target"
+    repeat=true
+    interval=1000
+    indicators=[
+      {
+        trigger: "pending",
+        // Use a wrapper with fixed width to prevent layout shift
+        content: "<p><span class='loading-wrap'>Loading...</span></p>"
+      },
+      {
+        trigger: "rejected",
+        // Same wrapper used here to maintain equal width
+        content: "<p><span class='loading-wrap'>Error</span></p><button>reload</button>"
+      }
+    ]
+    autoBody={
+      formData: true
+    }
+    memo=true
+    initId="id1"
+    allowedContentTypes=["text/html"]
+    disallowedTags=["script" "style" "iframe"]
+    sanitize=false
+  }}{{/request}}
+
+  {{r src="/api/test2"}}{{/r}}
+
+  {{#request
+    src="/api/register"
+    after="submit:#form"
+    repeat=false
+    indicators=[
+      {
+        trigger: "pending",
+        // Again, wrap to ensure no layout jump on change
+        content: "<p><span class='loading-wrap'>Loading...</span></p>"
+      }
+    ]
+  }}
+  {{/request}}
 </div>
 
 <style>
-    * {
-        font-size: 18px;
-    }
+  * {
+    font-size: 18px;
+  }
+
+  /* 👇 Fixed width wrapper to prevent flickering or shifting */
+  .loading-wrap {
+    display: inline-block;
+    min-width: 90px; /* Adjust this value as needed */
+    text-align: center;
+  }
 </style>
 
 <script>
-console.log("this is hmpl example")
+  // Just logging for demo
+  console.log("this is hmpl example");
 </script>


### PR DESCRIPTION
This PR fixes a minor layout shift that occurs between the "Loading..." text and the ✦✦✦ (stars) that appear afterward on the main page.

Previously, when the state changed from loading to fulfilled, the change in text length caused the layout to shift slightly, which was visually distracting.

## Changes

- Wrapped the `Loading...` and `Error` messages in a `<span>` with a `.loading-wrap` class
- Added a CSS rule for `.loading-wrap` with `min-width` and `inline-block` to maintain consistent spacing
- Verified that the layout no longer shifts when transitioning between request states

## Linked Issue

Closes #116 

----

Let me know if you’d like adjustments to the `min-width` value or want this applied elsewhere too.  

Thanks again for the opportunity to contribute 🙌
