### PR TITLE
fix: improve code block selection style

### DIFF
--- a/www/spec/src/index.html
+++ b/www/spec/src/index.html
@@ -80,6 +80,40 @@
     color: #b31d28 !important;
     background-color: #ffeef0 !important;
   }
+
+  .hljs ::selection,
+  .hljs::selection {
+    background-color: rgba(3, 102, 214, 0.3) !important;
+    color: inherit !important;
+  }
+
+  .hljs ::-moz-selection,
+  .hljs::-moz-selection {
+    background-color: rgba(3, 102, 214, 0.3) !important;
+    color: inherit !important;
+  }
+
+  pre ::selection,
+  code ::selection {
+    background-color: rgba(3, 102, 214, 0.3) !important;
+    color: inherit !important;
+  }
+
+  pre ::-moz-selection,
+  code ::-moz-selection {
+    background-color: rgba(3, 102, 214, 0.3) !important;
+    color: inherit !important;
+  }
+
+  *:target ::selection {
+    background-color: rgba(3, 102, 214, 0.3) !important;
+    color: inherit !important;
+  }
+
+  *:target ::-moz-selection {
+    background-color: rgba(3, 102, 214, 0.3) !important;
+    color: inherit !important;
+  }
 </style>
 <pre class="metadata">
   title: HMPL Template Language Specification
@@ -2196,6 +2230,40 @@ const elementObj = templateFn([
   .hljs-deletion {
     color: #b31d28 !important;
     background-color: #ffeef0 !important;
+  }
+
+  .hljs ::selection,
+  .hljs::selection {
+    background-color: rgba(3, 102, 214, 0.3) !important;
+    color: inherit !important;
+  }
+
+  .hljs ::-moz-selection,
+  .hljs::-moz-selection {
+    background-color: rgba(3, 102, 214, 0.3) !important;
+    color: inherit !important;
+  }
+
+  pre ::selection,
+  code ::selection {
+    background-color: rgba(3, 102, 214, 0.3) !important;
+    color: inherit !important;
+  }
+
+  pre ::-moz-selection,
+  code ::-moz-selection {
+    background-color: rgba(3, 102, 214, 0.3) !important;
+    color: inherit !important;
+  }
+
+  *:target ::selection {
+    background-color: rgba(3, 102, 214, 0.3) !important;
+    color: inherit !important;
+  }
+
+  *:target ::-moz-selection {
+    background-color: rgba(3, 102, 214, 0.3) !important;
+    color: inherit !important;
   }
 </style>
 


### PR DESCRIPTION
https://github.com/user-attachments/assets/4a6fc280-9152-4719-88e8-29fe39a6f251

- added selection styling for .hljs, pre, and code blocks
- applied a blue background (#0366d6) on selection
- text color remains unchanged to preserve syntax highlighting

fixes #113 
