### PR TITLE
Fix: docs: prevent Vue from parsing {{ }} in code blocks using v-pre

### DIFF
--- a/www/app/docs/examples.md
+++ b/www/app/docs/examples.md
@@ -12,19 +12,19 @@
 </div>
 
 ### Source
-
-```javascript
+```js v-pre
 import { compile } from "hmpl-js";
 
 const templateFn = compile(
-  `<div>
+  `
+  <div>
     <button class="getHTML">Get HTML!</button>
-    { {#request
+    {{#request
       src="/api/test"
       after="click:.getHTML"
       repeat=false
     }}
-      { {#indicator trigger="pending"}}
+      {{#indicator trigger="pending"}}
         <p>Loading...</p>
       {{/indicator}}
     {{/request}}
@@ -37,7 +37,6 @@ const elementObj = templateFn();
 
 wrapper.appendChild(elementObj.response);
 ```
-
 ## Registration form
 
 <div id="wrapper">
@@ -61,7 +60,8 @@ wrapper.appendChild(elementObj.response);
 
 ### Source
 
-```javascript
+```js v-pre
+
 import { compile } from "hmpl-js";
 
 const templateFn = compile(
@@ -78,7 +78,7 @@ const templateFn = compile(
     </div>
   </form>
   <p>
-    { {#request
+    {{#request
       src="/api/register"
       after="submit:#form"
       repeat=false
@@ -144,7 +144,7 @@ wrapper.appendChild(obj.response);
 
 ## Source
 
-```javascript
+```js v-pre
 import { compile } from "hmpl-js";
 
 const templateFn = compile(
@@ -168,7 +168,7 @@ const templateFn = compile(
         <td>Lays</td>
         <td>4</td>
       </tr>
-      { {#request
+      {{#request
         src="/api/products"
         after="submit:#form"
         autoBody=true


### PR DESCRIPTION
Wrapped HMPL code examples in fenced code blocks using ` ```javascript v-pre ` to prevent VuePress from processing `{{ }}` as Vue interpolations.

### Files Updated
- `docs/examples.md`

This fix ensures correct syntax highlighting and display of `{{#request}}` and similar HMPL constructs in the documentation.

![image](https://github.com/user-attachments/assets/67b102e4-5648-4bd4-8371-b76c4aa643fc)
