### PR TITLE
Fix: Example added to the introduction page with `hmpl-dom`

### DIFF
--- a/www/app/docs/introduction.md
+++ b/www/app/docs/introduction.md
@@ -130,3 +130,34 @@ wrapper.appendChild(obj.response);
     }
   }
 </script>
+
+## Example 3
+
+```html
+<template data-hmpl data-config-id="clicker-config">
+  <div>
+    <button data-action="increment" id="btn">Click!</button>
+    <div>
+      Clicks: {{#request src="/api/clicks" after="click:#btn"}}{{/request}}
+    </div>
+  </div>
+</template>
+```
+
+```javascript
+import { init } from "hmpl-dom";
+
+init([
+  {
+    id: "clicker-config",
+    value: {
+      compile: { memo: true },
+      templateFunction: ({ request: { event } }) => ({
+        body: JSON.stringify({
+          action: event.target.getAttribute("data-action")
+        })
+      })
+    }
+  }
+]);
+```


### PR DESCRIPTION
## What does this PR do?

This PR adds 'Example 3' to the introduction page, sourcing it from the DOM page.

Specifically, this involves taking the example from [https://hmpl-lang.dev/dom.html#example](https://hmpl-lang.dev/dom.html#example) and inserting it after 'Example 2' on the introduction page ([https://hmpl-lang.dev/introduction.html#example-2](https://hmpl-lang.dev/introduction.html#example-2)).

Closes: #135