### PR TITLE
Fix #143: Remove extra bottom space in footer in production build

### DIFF
--- a/www/app/src/pages/index.astro
+++ b/www/app/src/pages/index.astro
@@ -25,10 +25,11 @@
   }
   :global(main) {
     padding: 0;
+    padding-bottom: 0 !important;
     margin: 0;
   }
   :global(.main-frame) {
-    padding: 0 !important;
+    padding: 0 !important;   
     margin: 0 !important;
   }
 </style>


### PR DESCRIPTION
- Removed unintended bottom padding applied via scoped Astro styles
- Issue was only present in production build, not during local development
- Applied global override to reset footer padding