### PR TITLE
Add a sitemap to the App

### DIFF
--- a/www/app/astro.config.mjs
+++ b/www/app/astro.config.mjs
@@ -1,5 +1,6 @@
 // @ts-check
 import { defineConfig } from "astro/config";
+import sitemap from '@astrojs/sitemap';
 import starlight from "@astrojs/starlight";
 import vue from "@astrojs/vue";
 import starlightThemeNova from "starlight-theme-nova";
@@ -8,6 +9,9 @@ export default defineConfig({
   site: "https://hmpl-lang.dev",
   integrations: [
     vue(),
+    sitemap({
+      lastmod: new Date()
+    }),
     starlight({
       title: "HMPL Documentation",
       description:

--- a/www/app/package-lock.json
+++ b/www/app/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
+        "@astrojs/sitemap": "^3.5.1",
         "@astrojs/starlight": "^0.34.5",
         "@astrojs/vue": "^5.1.0",
         "astro": "^5.6.1",
@@ -319,14 +320,14 @@
       }
     },
     "node_modules/@astrojs/sitemap": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.4.1.tgz",
-      "integrity": "sha512-VjZvr1e4FH6NHyyHXOiQgLiw94LnCVY4v06wN/D0gZKchTMkg71GrAHJz81/huafcmavtLkIv26HnpfDq6/h/Q==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.5.1.tgz",
+      "integrity": "sha512-uX5z52GLtQTgOe8r3jeGmFRYrFe52mdpLYJzqjvL1cdy5Kg3MLOZEvaZ/OCH0fSq0t7e50uJQ6oBMZG0ffszBg==",
       "license": "MIT",
       "dependencies": {
         "sitemap": "^8.0.0",
         "stream-replace-string": "^2.0.0",
-        "zod": "^3.24.2"
+        "zod": "^3.24.4"
       }
     },
     "node_modules/@astrojs/starlight": {

--- a/www/app/package.json
+++ b/www/app/package.json
@@ -12,6 +12,7 @@
     "astro": "astro"
   },
   "dependencies": {
+    "@astrojs/sitemap": "^3.5.1",
     "@astrojs/starlight": "^0.34.5",
     "@astrojs/vue": "^5.1.0",
     "astro": "^5.6.1",


### PR DESCRIPTION
## ✨ Summary of Changes

- Integrated the `@astrojs/sitemap` package to automatically a sitemap for the site
- Configured the sitemap to include `lastmod` metadata, using the timestamp from when the site was last built

🔍 Why This Matters

Adding a sitemap improves SEO and helps search engines index the site efficiently. Setting the lastmod ensures crawlers understand when content was last updated, improving accuracy in indexing.

📌 Closes #163 – Add Sitemap Generation with Astro Starlight
