### PR TITLE
Updated footer link to Docs as per issue #195

### DIFF
--- a/www/app/src/components/HomePage.vue
+++ b/www/app/src/components/HomePage.vue
@@ -773,12 +773,10 @@ src="https://raw.githubusercontent.com/hmpl-language/media/refs/heads/main/devhu
                   rel="nooferer noopener"
                   class="footer_item_link"
                   href="https://spec.hmpl-lang.dev"
-                  >Spec</a
+                  >Docs</a
                 >
               </li>
-              <li class="footer_item">
-                <a class="footer_item_link" href="/introduction">Overview</a>
-              </li>
+              
               <li class="footer_item">
                 <a
                   class="footer_item_link"


### PR DESCRIPTION
Updated the first two footer links and replaced them with a Docs link 
pointing to https://hmpl-lang.dev/introduction/, as mentioned in issue #195.

<img width="1901" height="869" alt="image" src="https://github.com/user-attachments/assets/3e711aa6-5b0c-4da5-b5a7-6758dee61e7c" />
