### PR TITLE
fix:Restore the ability to copy code in a blog post

### DIFF
--- a/www/blog/.bundle/config
+++ b/www/blog/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_PATH: "vendor/bundle"

--- a/www/blog/_layouts/base.html
+++ b/www/blog/_layouts/base.html
@@ -8,7 +8,7 @@
   <!-- Theme CSS -->
   <link rel="stylesheet" href="{{ "/assets/main.css" | relative_url }}">
   
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.11/clipboard.min.js"></script>
+  <script src="https://unpkg.com/clipboard@2/dist/clipboard.min.js"></script>
 
 </head>
 

--- a/www/blog/_layouts/base.html
+++ b/www/blog/_layouts/base.html
@@ -8,7 +8,8 @@
   <!-- Theme CSS -->
   <link rel="stylesheet" href="{{ "/assets/main.css" | relative_url }}">
   
-  <script src="https://unpkg.com/clipboard.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.11/clipboard.min.js"></script>
+
 </head>
 
 <body>


### PR DESCRIPTION
The `https://unpkg.com/clipboard.js` is not working, so I switched to the CDN version, and it worked.

resolves #181