### PR TITLE
refactor(types): replace comment to use 'block helper' wording (#176)

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -62,7 +62,7 @@ type HMPLRequestInitFunction = (
  * An object containing information about a request and optionally related DOM elements or metadata.
  */
 interface HMPLRequestsObject extends HMPLRequestInfo {
-  arrId?: number; // Needed to replace the request object with a comment
+  arrId?: number; // Needed to replace the block helper with a comment
   el?: Comment; // Optional comment node related to the request
   nodeId?: number; // Optional ID of the node associated with this request
 }


### PR DESCRIPTION
## Update terminology in types.ts comments
This PR addresses issue #176 by updating outdated terminology in the codebase to reflect current naming conventions.
Changes Made

Updated comment in HMPLRequestsObject interface to use "block helper" instead of "request object"
This aligns documentation with the project's evolved terminology and makes the code easier to understand for new contributors

**Impact**
Single-line documentation fix with no functional changes. The update improves code clarity and consistency throughout the project.
Closes #176