### PR TITLE
Fix: Fetch all contributors with pagination

### DIFF
--- a/www/app/src/components/HomePage.vue
+++ b/www/app/src/components/HomePage.vue
@@ -934,14 +934,37 @@ export default {
     );
     observer.observe(chart);
 
-    const url = "https://api.github.com/repos/hmpl-language/hmpl/contributors";
     const contributorsGrid = document.querySelector(".contributors-grid");
 
-    axios
-      .get(url)
-      .then((response) => {
-        const contributors = response.data;
+    // Function to fetch all contributors with pagination
+    const fetchAllContributors = async () => {
+      const allContributors = [];
+      let page = 1;
+      let hasMore = true;
 
+      while (hasMore) {
+        try {
+          const url = `https://api.github.com/repos/hmpl-language/hmpl/contributors?page=${page}&per_page=100`;
+          const response = await axios.get(url);
+          
+          if (response.data.length === 0) {
+            hasMore = false;
+          } else {
+            allContributors.push(...response.data);
+            page++;
+          }
+        } catch (error) {
+          console.error(`Error fetching contributors page ${page}:`, error);
+          hasMore = false;
+        }
+      }
+
+      return allContributors;
+    };
+
+    // Fetch and display all contributors
+    fetchAllContributors()
+      .then((contributors) => {
         contributors.forEach((contributor) => {
           const contributorDiv = document.createElement("div");
           contributorDiv.className = "contributor";
@@ -981,7 +1004,7 @@ export default {
         contributorsGrid.appendChild(additionalContributor);
       })
       .catch((error) => {
-        console.error("Error fetching data:", error);
+        console.error("Error fetching contributors:", error);
       });
 
     const buttons = document.querySelectorAll(".fade-in-effect");


### PR DESCRIPTION
This PR resolves issue #171 by implementing proper pagination to display all contributors on the landing page instead of just 30.

### Problem
The GitHub API was only returning 30 contributors because it defaults to 30 items per page without pagination handling.

### Solution
Implemented a `fetchAllContributors()` function that:
- Fetches contributors in pages of 100 (maximum allowed)
- Continues until all contributors are retrieved
- Handles errors gracefully for each page
- Minimizes API calls while respecting rate limits

### Changes
Modified `www/app/src/components/HomePage.vue` to replace the single API call with paginated requests, ensuring all project contributors are displayed.

**Closes #171**