### PR TITLE
Add pagination to blog main page 

### DIFF
--- a/www/blog/_config.yml
+++ b/www/blog/_config.yml
@@ -29,6 +29,9 @@ timezone: UTC
 permalink: /:year/:month/:day/:title/
 excerpt_separator: <!--more-->
 
+# Pagination Configuration
+paginate: 5
+
 # Theme Configuration
 # theme: minima  # Disabled due to Sass compatibility issues
 

--- a/www/blog/assets/main.scss
+++ b/www/blog/assets/main.scss
@@ -510,6 +510,58 @@ body {
   content: " ✓";
 }
 
+// Pagination Styles
+.pager {
+  margin-top: 30px;
+  text-align: center;
+}
+
+.pagination {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  gap: 10px;
+}
+
+.pagination li {
+  margin: 0;
+}
+
+.pagination a,
+.pagination .current-page,
+.pagination .pager-edge {
+  display: inline-block;
+  padding: 8px 12px;
+  border: 1px solid #e5e7eb;
+  border-radius: 4px;
+  text-decoration: none;
+  color: #374151;
+  font-size: 14px;
+  font-weight: 500;
+  transition: all 0.2s ease;
+}
+
+.pagination a:hover {
+  background-color: #f3f4f6;
+  border-color: #d1d5db;
+  color: #1f2937;
+}
+
+.pagination .current-page {
+  background-color: #1e90ff;
+  color: white;
+  border-color: #1e90ff;
+}
+
+.pagination .pager-edge {
+  color: #9ca3af;
+  border-color: #e5e7eb;
+  cursor: default;
+}
+
 // Mobile responsive
 @media (max-width: 600px) {
   .wrapper {


### PR DESCRIPTION
## Add pagination to blog main page

This PR implements issue #184 by adding pagination to the blog's main page, limiting display to 5 posts per page.

### Changes Made
- **Enabled pagination** in `_config.yml` with 5 posts per page limit
- **Added pagination CSS** in `main.scss` with responsive styling and hover effects

### Implementation Details
The Jekyll blog framework already included pagination logic in the `home.html` template - it just needed to be activated. This implementation:
- Displays 5 posts per page (13 total posts = 3 pages)
- Shows Previous/Next navigation buttons
- Highlights current page number in blue
- Fully responsive design matching existing blog aesthetic
- Smooth hover transitions for better UX


### Testing
The pagination controls will appear at the bottom of the main blog page once the Jekyll site rebuilds.

**Closes #184**