### PR TITLE
Fix: Update HMPL v2 Syntax to v3 in Blog Posts

### DIFF
--- a/www/blog/_posts/2024-08-09-how-to-reduce-javascript-file-size-on-client.md
+++ b/www/blog/_posts/2024-08-09-how-to-reduce-javascript-file-size-on-client.md
@@ -46,7 +46,7 @@ document.querySelector("#app").appendChild(
   hmpl.compile(
     `<div>
         <button>Click!</button>
-        {% raw %}<div>Clicks: {{ src: "/api/clicks", after: "click:button" }}</div>{% endraw %}
+        {% raw %}<div>Clicks: {{#request src="/api/clicks" after="click:button"}}{{/request}}</div>{% endraw %}
     </div>`
   )().response
 );

--- a/www/blog/_posts/2024-10-03-memoization-in-hmpl.md
+++ b/www/blog/_posts/2024-10-03-memoization-in-hmpl.md
@@ -77,7 +77,7 @@ Since HTML is a template language for displaying the user interface from the ser
 const newDiv = compile(
   `<div>
       <button>Get the square root of 256</button>
-      <div>{% raw %}{{ src: "/api/getTheSquareRootOf256", after: "click:button" }}{% endraw %}</div>
+      <div>{% raw %}{{#request src="/api/getTheSquareRootOf256" after="click:button"}}{{/request}}{% endraw %}</div>
   </div>`
 )().response;
 ```
@@ -92,7 +92,7 @@ Specifically to optimize this process, an additional field was introduced, which
 const newDiv = compile(
   `<div>
       <button>Get the square root of 256</button>
-      <div>{% raw %}{{ src: "/api/getTheSquareRootOf256", memo:true, after: "click:button" }}{% endraw %}</div>
+      <div>{% raw %}{{#request src="/api/getTheSquareRootOf256" memo=true after="click:button"}}{{/request}}{% endraw %}</div>
   </div>`
 )().response;
 ```

--- a/www/blog/_posts/2024-12-05-hmpl-integration-with-json5.md
+++ b/www/blog/_posts/2024-12-05-hmpl-integration-with-json5.md
@@ -176,7 +176,7 @@ const templateFn = hmpl.compile(`{${request}}`);
 **mail.hmpl**:
 
 ```html
-<div>{% raw %}{{ src: "/api/test" }}{% endraw %}</div>
+<div>{% raw %}{{#request src="/api/test"}}{{/request}}{% endraw %}</div>
 ```
 
 Therefore, I think that integration with JSON5 is the best way to make sites even faster and smaller in size. Now, it's generally super convenient, because you can just copy an object from JavaScript and paste it into an HTML file.

--- a/www/blog/_posts/2024-12-07-how-to-share-components-between-sites.md
+++ b/www/blog/_posts/2024-12-07-how-to-share-components-between-sites.md
@@ -251,7 +251,7 @@ We use method 1, since index.html is the default on our sites.
     <script src="https://unpkg.com/hmpl-js/dist/hmpl.min.js"></script>
     <script>
       const templateFn = hmpl.compile(
-        `<div id="wrapper">{% raw %}{{ src: "https://.../api/getButton" }}{% endraw %}</div>`
+        `<div id="wrapper">{% raw %}{{#request src="https://.../api/getButton"}}{{/request}}{% endraw %}</div>`
       );
       const btnWrapper = templateFn().response;
       document.body.append(btnWrapper);

--- a/www/blog/_posts/2024-12-18-creating-a-gallery-app-in-javascript-with-hmpl.md
+++ b/www/blog/_posts/2024-12-18-creating-a-gallery-app-in-javascript-with-hmpl.md
@@ -114,7 +114,7 @@ It is worth noting that there are two objects marked here. The first one is trig
 **Title.hmpl**
 
 ```html
-<h1 id="title">{% raw %}{{ src: "http://localhost:8000/api/title" }}{% endraw %}</h1>
+<h1 id="title">{% raw %}{{#request src="http://localhost:8000/api/title"}}{{/request}}{% endraw %}</h1>
 ```
 
 Here, the objects will be changed to HTML from the server. Now, they should be connected. To do this, import them into main.js:

--- a/www/blog/_posts/2025-02-27-how-to-reduce-web-application-bundle-size.md
+++ b/www/blog/_posts/2025-02-27-how-to-reduce-web-application-bundle-size.md
@@ -94,7 +94,7 @@ Working with the module looks something like this:
 const templateFn = hmpl.compile(
   `<div>
       <button data-action="increment" id="btn">Click!</button>
-      <div>Clicks: {% raw %}{{ src: "/api/clicks", after: "click:#btn" }}{% endraw %}</div>
+      <div>Clicks: {% raw %}{{#request src="/api/clicks" after="click:#btn"}}{{/request}}{% endraw %}</div>
   </div>`
 );
 


### PR DESCRIPTION
## What changed
Updated old HMPL v2 syntax to v3 across blog posts. Found 7 instances of the old `{{ src: "..." }}` pattern and replaced them with the new `{{#request src="..."}}{{/request}}` syntax.

## Files updated
- `2025-02-27-how-to-reduce-web-application-bundle-size.md`
- `2024-12-18-creating-a-gallery-app-in-javascript-with-hmpl.md`
- `2024-12-07-how-to-share-components-between-sites.md`
- `2024-12-05-hmpl-integration-with-json5.md`
- `2024-10-03-memoization-in-hmpl.md` (2 instances)
- `2024-08-09-how-to-reduce-javascript-file-size-on-client.md`


## Why
The blog was showing outdated syntax examples. This brings everything up to date with the current v3 syntax so readers see the correct patterns.

Closes #186
