### PR TITLE
Apply UpButton utility to all docs and index page

### DIFF
--- a/www/app/src/components/HomePage.vue
+++ b/www/app/src/components/HomePage.vue
@@ -675,13 +675,4 @@ export default HomePageScript;
       >issue list</a
     >.
   </div>
-  <!-- Scroll to top button -->
-  <button
-    class="scroll-to-top"
-    v-show="showScroll"
-    @click="scrollToTop"
-    aria-label="Scroll to top"
-  >
-    <i class="fas fa-arrow-up" aria-hidden="true"></i>
-  </button>
 </template>

--- a/www/app/src/content/docs/block-helpers/indicator.mdx
+++ b/www/app/src/content/docs/block-helpers/indicator.mdx
@@ -1,6 +1,7 @@
 ---
 title: indicator
 description: About indicator block helper
+layout: "../../../layout/CustomUpButtonLayout.astro"
 head:
   - tag: meta
     attrs:

--- a/www/app/src/content/docs/block-helpers/request.mdx
+++ b/www/app/src/content/docs/block-helpers/request.mdx
@@ -1,6 +1,7 @@
 ---
 title: request
 description: About request block helper
+layout: "../../../layout/CustomUpButtonLayout.astro"
 head:
   - tag: meta
     attrs:

--- a/www/app/src/content/docs/context/request.mdx
+++ b/www/app/src/content/docs/context/request.mdx
@@ -1,6 +1,7 @@
 ---
 title: Context
 description: About request context
+layout: "../../../layout/CustomUpButtonLayout.astro"
 head:
   - tag: meta
     attrs:

--- a/www/app/src/content/docs/examples.mdx
+++ b/www/app/src/content/docs/examples.mdx
@@ -1,6 +1,7 @@
 ---
 title: Examples
 description: Real-world examples and use cases for HMPL
+layout: "../../layout/CustomUpButtonLayout.astro"
 head:
   - tag: meta
     attrs:

--- a/www/app/src/content/docs/getting-started.mdx
+++ b/www/app/src/content/docs/getting-started.mdx
@@ -1,6 +1,7 @@
 ---
 title: Getting Started
 description: Quick start guide for HMPL
+layout: "../../layout/CustomUpButtonLayout.astro"
 head:
   - tag: meta
     attrs:

--- a/www/app/src/content/docs/installation.mdx
+++ b/www/app/src/content/docs/installation.mdx
@@ -1,6 +1,7 @@
 ---
 title: Installation
 description: Install and set up HMPL in your project
+layout: "../../layout/CustomUpButtonLayout.astro"
 head:
   - tag: meta
     attrs:

--- a/www/app/src/content/docs/introduction.mdx
+++ b/www/app/src/content/docs/introduction.mdx
@@ -1,6 +1,7 @@
 ---
 title: Introduction
 description: Learn about HMPL
+layout: "../../layout/CustomUpButtonLayout.astro"
 head:
   - tag: meta
     attrs:

--- a/www/app/src/content/docs/objects/hmpl.mdx
+++ b/www/app/src/content/docs/objects/hmpl.mdx
@@ -1,6 +1,7 @@
 ---
 title: hmpl
 description: About HMPL object
+layout: "../../../layout/CustomUpButtonLayout.astro"
 head:
   - tag: meta
     attrs:

--- a/www/app/src/content/docs/syntax/attribute.mdx
+++ b/www/app/src/content/docs/syntax/attribute.mdx
@@ -1,6 +1,7 @@
 ---
 title: Attribute
 description: About attribute used in HMPL
+layout: "../../../layout/CustomUpButtonLayout.astro"
 head:
   - tag: meta
     attrs:

--- a/www/app/src/content/docs/syntax/block-helper.mdx
+++ b/www/app/src/content/docs/syntax/block-helper.mdx
@@ -1,6 +1,7 @@
 ---
 title: Block helper
 description: About block helper used in HMPL
+layout: "../../../layout/CustomUpButtonLayout.astro"
 head:
   - tag: meta
     attrs:

--- a/www/app/src/layout/CustomUpButtonLayout.astro
+++ b/www/app/src/layout/CustomUpButtonLayout.astro
@@ -1,0 +1,6 @@
+---
+import UpButton from "../components/UpButton.vue";
+---
+
+<slot />
+<UpButton client:load />

--- a/www/app/src/pages/index.astro
+++ b/www/app/src/pages/index.astro
@@ -1,8 +1,9 @@
 ---
-  import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
-  import StructuredData from '../components/StructuredData.astro';
-
+import StarlightPage from "@astrojs/starlight/components/StarlightPage.astro";
+import StructuredData from "../components/StructuredData.astro";
+import UpButton from "../components/UpButton.vue";
 ---
+
 <style>
   * {
     margin: 0;
@@ -31,27 +32,28 @@
     margin: 0;
   }
   :global(.main-frame) {
-    padding: 0 !important;   
+    padding: 0 !important;
     margin: 0 !important;
   }
 </style>
 
-<StarlightPage frontmatter={{ title: 'HMPL.js' }} hasSidebar={false}>
-  <StructuredData 
+<StarlightPage frontmatter={{ title: "HMPL.js" }} hasSidebar={false}>
+  <StructuredData
     title="HMPL.js - Lightweight Server-Oriented Template Language for JavaScript"
     description="HMPL.js is a lightweight server-oriented template language for JavaScript. Fetch HTML, render it safely, and keep apps dynamic, modern, and small. Alternative to HTMX and Alpine.js."
     url="https://hmpl-lang.dev"
   />
   <div id="app"></div>
+  <UpButton client:load />
 </StarlightPage>
 
 <script is:inline>
-  document.documentElement.dataset.theme = 'light';
+  document.documentElement.dataset.theme = "light";
 </script>
 
 <script>
-  import { createApp } from 'vue'
-  import LandingPage from '../components/HomePage.vue'
+  import { createApp } from "vue";
+  import LandingPage from "../components/HomePage.vue";
 
-  createApp(LandingPage).mount('#app')
+  createApp(LandingPage).mount("#app");
 </script>


### PR DESCRIPTION
Issue: https://github.com/hmpl-language/hmpl/issues/252

**Context:**
The UpButton used to navigate to top of the page through auto-scroll developed in #247 was only applied to `getting-started` doc. This PR applies that component into all docs and index page."

**What I did**
1. Created a custom layout with the `UpButton` component and used that layout for the doc pages
2. Removed the `Scroll` in-line component in `index.astro`, as it was visible on desktop and mobile, and rendered the `UpButton` component as a sibling to `#app` component. _As per the [suggested direction ](https://github.com/hmpl-language/hmpl/issues/247#issuecomment-3586112063) from the parent work, the icon should only be visible on mobile view._

**Test Sample**

https://github.com/user-attachments/assets/f686e079-0dd9-4a01-ace6-0c2dd3892360

https://github.com/user-attachments/assets/3c9be522-f394-4a92-8791-34e54df57e57
