### PR TITLE
Show UpButton in both Desktop & Mobile

### DIFF
--- a/www/app/src/components/UpButton.vue
+++ b/www/app/src/components/UpButton.vue
@@ -89,12 +89,6 @@ onUnmounted(() => {
   transform: scale(0.95);
 }
 
-@media (min-width: 768px) {
-  .scroll-to-top {
-    display: none;
-  }
-}
-
 @media (max-width: 600px) {
   .scroll-to-top {
     right: 14px;


### PR DESCRIPTION
**Context**
As per the discussion, the UpButton that helps to navigates to top of the page should be visible on both desktop and mobile.